### PR TITLE
fix: type annotations crash

### DIFF
--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import requests, time, os, re
 from TSRUrl import TSRUrl
 from logger import logger

--- a/src/TSRSession.py
+++ b/src/TSRSession.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import requests, webbrowser, os
 from exceptions import InvalidCaptchaCode
 from typing import Optional

--- a/src/TSRUrl.py
+++ b/src/TSRUrl.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from exceptions import InvalidURL
 from logger import logger
 import re, requests

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from TSRUrl import TSRUrl
 from TSRDownload import TSRDownload
 from logger import logger


### PR DESCRIPTION
Fixes an issue with older versions of Python (Python 3.8) where certain type annotations crash the script.

resolves #7