### PR TITLE
Fix duplicate files not being overwritten

### DIFF
--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -46,10 +46,15 @@ class TSRDownload:
             file.write(chunk)
         file.close()
         logger.debug(f"Removing .part from file name: {fileName}")
-        os.rename(
-            f"{downloadPath}/{fileName}.part",
-            f"{downloadPath}/{fileName}",
-        )
+        if os.path.exists(f"{downloadPath}/{fileName}"):
+            logger.debug(f"{downloadPath}/{fileName} Already exists! Replacing file")
+            os.replace(f"{downloadPath}/{fileName}.part", f"{downloadPath}/{fileName}")
+        else:
+            logger.debug(f"{downloadPath}/{fileName} doesn't exist! Renaming file")
+            os.rename(
+                f"{downloadPath}/{fileName}.part",
+                f"{downloadPath}/{fileName}",
+            )
         return fileName
 
     @classmethod

--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -23,23 +23,29 @@ class TSRDownload:
             time.sleep(timeToSleep / 1000)
 
         downloadUrl = self.__getDownloadUrl()
+        logger.debug(f"Got downloadUrl: {downloadUrl}")
         fileName = self.__getFileName(downloadUrl)
+        logger.debug(f"Got fileName: {fileName}")
 
         startingBytes = (
             os.path.getsize(f"{downloadPath}/{fileName}.part")
             if os.path.exists(f"{downloadPath}/{fileName}.part")
             else 0
         )
+        logger.debug(f"Got startingBytes: {startingBytes}")
         request = self.session.get(
             downloadUrl,
             stream=True,
             headers={"Range": f"bytes={startingBytes}-"},
         )
+        logger.debug(f"Request status is: {request.status_code}")
         file = open(f"{downloadPath}/{fileName}.part", "wb")
 
-        for chunk in request.iter_content(1024 * 128):
+        for index, chunk in enumerate(request.iter_content(1024 * 128)):
+            logger.debug(f"Downloading chunk #{index} of {downloadUrl}")
             file.write(chunk)
         file.close()
+        logger.debug(f"Removing .part from file name: {fileName}")
         os.rename(
             f"{downloadPath}/{fileName}.part",
             f"{downloadPath}/{fileName}",

--- a/src/main.py
+++ b/src/main.py
@@ -10,9 +10,12 @@ import clipboard, time, os
 
 
 def processTarget(url: TSRUrl, tsrdlsession: str, downloadPath: str):
-    downloader = TSRDownload(url, tsrdlsession)
-    downloader.download(downloadPath)
-    logger.info(f"Completed download for: {url.url}")
+    try:
+        downloader = TSRDownload(url, tsrdlsession)
+        downloader.download(downloadPath)
+        logger.info(f"Completed download for: {url.url}")
+    except Exception as e:
+        logger.error(e)
 
     return url
 
@@ -26,6 +29,7 @@ def callback(url: TSRUrl):
 
 
 def updateUrlFile():
+    logger.debug(f"Updating URL file")
     if CONFIG["saveDownloadQueue"]:
         open(CURRENT_DIR + "/urls.txt", "w").write(
             "\n".join([*runningDownloads, *downloadQueue])

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ def processTarget(url: TSRUrl, tsrdlsession: str, downloadPath: str):
 
 
 def callback(url: TSRUrl):
+    logger.debug(f"Removing {url.url} from queue")
     runningDownloads.remove(url.url)
     updateUrlFile()
     if len(runningDownloads) == 0:
@@ -35,6 +36,11 @@ if __name__ == "__main__":
     lastPastedText = ""
     runningDownloads: list[str] = []
     downloadQueue: list[str] = []
+
+    logger.debug(f'downloadDirectory: {CONFIG["downloadDirectory"]}')
+    logger.debug(f'maxActiveDownloads: {CONFIG["maxActiveDownloads"]}')
+    logger.debug(f'saveDownloadQueue: {CONFIG["saveDownloadQueue"]}')
+    logger.debug(f'debug: {CONFIG["debug"]}')
 
     if not os.path.exists(CONFIG["downloadDirectory"]):
         raise FileNotFoundError(


### PR DESCRIPTION
Fix an issue where processes freeze up, due to them erroring, when trying to rename a file to a file which already exists. 

fixes #10