### PR TITLE
Standardize Paths + Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "Super simple rust library to display images in the terminal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {self, nixpkgs, flake-utils}:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {inherit system;};
+        pkgs-python = pkgs.python3.pkgs;
+
+        clipboard = with pkgs-python; buildPythonPackage {
+          pname = "clipboard";
+          version = "0.0.4";
+          src = fetchPypi {
+            pname = "clipboard";
+            version = "0.0.4";
+            sha256 = "sha256-pyp46cm/aNocPynuAiQX0T7J44JLURVZ/StwKx3VuBc=";
+          };
+          propagatedBuildInputs = [pyperclip];
+          doCheck = false;
+          pyproject = true;
+          build-system = [setuptools];
+        };
+
+        pythonEnv = pkgs.python3.withPackages (ps: [
+          ps.requests
+          ps.platformdirs
+          clipboard
+        ]);
+        pname = "tsr-downloader";
+        app = with pkgs-python; buildPythonApplication {
+          inherit pname;
+          version = "0.4.2";
+          src = ./.;
+          format = "other";
+          installPhase = ''
+            mkdir -p $out/lib/src
+            cp -r src/* $out/lib/src
+
+            makeWrapper ${pythonEnv}/bin/python $out/bin/${pname} \
+              --prefix PATH : ${pkgs.wl-clipboard}/bin \
+              --add-flags "$out/lib/src/main.py"
+          '';
+        };
+      in {
+        packages.default = app;
+
+        apps.default = {
+          type = "app";
+          program = "${app}/bin/${pname}";
+        };
+      }
+    );
+}

--- a/src/TSRSession.py
+++ b/src/TSRSession.py
@@ -3,8 +3,7 @@ import requests, webbrowser, os
 from exceptions import InvalidCaptchaCode
 from typing import Optional
 from logger import logger
-
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+from config import STATE_DIR
 
 
 class TSRSession:
@@ -82,13 +81,13 @@ class TSRSession:
         if len(captcha_image.content) == 0:
             raise Exception("Captcha has a length of 0.")
 
-        with open(f"{CURRENT_DIR}/captcha.png", "wb") as f:
+        with open(f"{STATE_DIR}/captcha.png", "wb") as f:
             for chunk in captcha_image.iter_content(1024 * 1024):
                 f.write(chunk)
 
     @classmethod
     def __openImageInBrowser(self) -> None:
-        webbrowser.open_new_tab(f"{CURRENT_DIR}/captcha.png")
+        webbrowser.open_new_tab(f"{STATE_DIR}/captcha.png")
 
     @classmethod
     def __getTSRDLTicketCookie(self) -> str:

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,0 @@
-{
-    "downloadDirectory": "./",
-    "maxActiveDownloads": 4,
-    "saveDownloadQueue": true,
-    "debug": false
-}

--- a/src/config.py
+++ b/src/config.py
@@ -1,13 +1,36 @@
-import json, os, typing
+import json, typing
+from pathlib import Path
+from platformdirs import user_config_dir, user_state_dir, user_downloads_dir
 
-CONFIG_DICT = typing.TypedDict(
-    "Config Dict",
-    {
-        "downloadDirectory": str,
-        "maxActiveDownloads": int,
-        "saveDownloadQueue": bool,
-        "debug": bool,
-    },
-)
-CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-CONFIG: CONFIG_DICT = json.load(open(CURRENT_DIR + "/config.json", "r"))
+# Paths
+APP_AUTHOR = "Xientraa"
+APP_NAME = "TSR-Downloader"
+
+CONFIG_DIR = Path(user_config_dir(APP_NAME, APP_AUTHOR))
+STATE_DIR = Path(user_state_dir(APP_NAME, APP_AUTHOR))
+DOWNLOADS_DIR = Path(user_downloads_dir()) / APP_NAME
+
+for dir in [CONFIG_DIR, STATE_DIR, DOWNLOADS_DIR]:
+    dir.mkdir(parents=True, exist_ok=True)
+
+
+# Config
+class ConfigDict(typing.TypedDict):
+    downloadDirectory: str
+    maxActiveDownloads: int
+    saveDownloadQueue: bool
+    debug: bool
+
+
+DEFAULT_CONFIG: ConfigDict = {
+    "downloadDirectory": str(DOWNLOADS_DIR),
+    "maxActiveDownloads": 4,
+    "saveDownloadQueue": True,
+    "debug": False,
+}
+
+CONFIG_FILE = CONFIG_DIR / "config.json"
+if not CONFIG_FILE.exists():
+    CONFIG_FILE.write_text(json.dumps(DEFAULT_CONFIG, indent=2))
+
+CONFIG = json.loads(CONFIG_FILE.read_text())

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from logger import logger
 from exceptions import *
 from multiprocessing import Pool
 from TSRSession import TSRSession
-from config import CONFIG, CURRENT_DIR
+from config import CONFIG, STATE_DIR
 import clipboard, time, os
 
 
@@ -31,7 +31,7 @@ def callback(url: TSRUrl):
 def updateUrlFile():
     logger.debug(f"Updating URL file")
     if CONFIG["saveDownloadQueue"]:
-        open(CURRENT_DIR + "/urls.txt", "w").write(
+        open(STATE_DIR / "urls.txt", "w").write(
             "\n".join(
                 [
                     DETAILS_URL + str(id)
@@ -60,14 +60,14 @@ if __name__ == "__main__":
 
     session = None
     sessionId = None
-    if os.path.exists(CURRENT_DIR + "/session"):
-        sessionId = open(CURRENT_DIR + "/session", "r").read()
+    if os.path.exists(STATE_DIR / "session"):
+        sessionId = open(STATE_DIR / "session", "r").read()
 
     while session is None:
         try:
             session = TSRSession(sessionId)
             if hasattr(session, "tsrdlsession") and session.tsrdlsession != "":
-                open(CURRENT_DIR + "/session", "w").write(session.tsrdlsession)
+                open(STATE_DIR / "session", "w").write(session.tsrdlsession)
                 logger.info("Session with captcha successfully created")
         except InvalidCaptchaCode:
             logger.error(
@@ -75,8 +75,8 @@ if __name__ == "__main__":
             )
             sessionId = None
 
-    if os.path.exists(CURRENT_DIR + "/urls.txt") and CONFIG["saveDownloadQueue"]:
-        for url in open(CURRENT_DIR + "/urls.txt", "r").read().split("\n"):
+    if os.path.exists(STATE_DIR / "urls.txt") and CONFIG["saveDownloadQueue"]:
+        for url in open(STATE_DIR / "urls.txt", "r").read().split("\n"):
             try:
                 url = TSRUrl(url)
                 if url.isVipExclusive():


### PR DESCRIPTION
This PR provides two features: path standardization and nix flake.

## Paths standardization
Instead of saving temporary files and downloads and handling config inside the src folder, use the standard platforms dirs for config, state and downloads. This is cleaner and more predictable.

- `config`: the `config.json` file
- `state`: `urls.txt`, `session` and `captcha.png` files
- `downloads`: downloaded CC packages

Linux
```
config: ~/.config/TSR-Downloader/
state: ~/.local/state/TSR-Downloader/
downloads: ~/Downloads/TSR-Downloader/
```

Windows
```
config: C:\Users\<user>\AppData\Roaming\Xientraa\TSR-Downloader\
state: C:\Users\<user>\AppData\Local\Xientraa\TSR-Downloader\
downloads: C:\Users\<user>\Downloads\TSR-Downloader\
```

macOS
```
config: ~/Library/Application Support/TSR-Downloader/
state: ~/Library/Application Support/TSR-Downloader/state/
downloads: ~/Downloads/TSR-Downloader/
```

## Nix flake
The nix flake allows to install this package using the nix package manager, especially useful to use this project on NixOS.
As the original paths wrote inside the source folder which are immutable in the nix store, this requires the earlier path standardization.

### Usage on Nix
Simply run with
`nix run github:Xientraa/The-Sims-Resource-Downloader`
(`nix run github:BinaryQuantumSoul/The-Sims-Resource-Downloader` before PR)
or add it to your flake inputs and add the default package to your home or system packages.