### PR TITLE
hack around missing scheme in isVipExclusive

### DIFF
--- a/src/TSRUrl.py
+++ b/src/TSRUrl.py
@@ -35,7 +35,10 @@ class TSRUrl:
         return isUrlValid
 
     def isVipExclusive(self) -> bool:
-        r = requests.get(self.url)
+        if not self.url.startswith("https://"):
+            r = requests.get("https://" + self.url)
+        else:
+            r = requests.get(self.url)
         return "VIP Exclusive" in r.text
 
     @staticmethod


### PR DESCRIPTION
```
[2026-03-03 22:53:19,887] [ERROR] requests.exceptions.MissingSchema: Invalid URL 'www.thesimsresource.com/members/[...]/': No scheme supplied. Perhaps you meant http://www.thesimsresource.com/members/[...]/?
```
followed by errors in logger, followed by crash