### PR TITLE
fix: resolves assets download bug due to empty session token caused due to updated workflow

### DIFF
--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -12,12 +12,12 @@ def stripForbiddenCharacters(string: str) -> str:
 class TSRDownload:
     @classmethod
     def __init__(self, url: TSRUrl, sessionId: str):
-        self.session: requests.Session = requests.Session()
-        self.session.cookies.set("tsrdlsession", sessionId)
-
         self.url: TSRUrl = url
+        self.session: requests.Session = requests.Session()
+        self.TSRDLTicket = self.__getTSRDLTicket()
+        self.session.cookies.set("tsrdlsession", sessionId or  self.__getTSRDLTicketCookie())
         self.ticketInitializedTime: float = -1.0
-        self.__getTSRDLTicketCookie()
+        
 
     @classmethod
     def download(self, downloadPath: str) -> str:
@@ -71,7 +71,7 @@ class TSRDownload:
     @classmethod
     def __getDownloadUrl(self) -> str:
         response = self.session.get(
-            f"https://www.thesimsresource.com/ajax.php?c=downloads&a=getdownloadurl&ajax=1&itemid={self.url.itemId}&mid=0&lk=0",
+            f"https://www.thesimsresource.com/ajax.php?c=downloads&a=getdownloadurl&ajax=1&itemid={self.url.itemId}&mid=0&lk=0&ticket={self.TSRDLTicket}",
             cookies=self.session.cookies,
         )
         responseJSON = response.json()
@@ -87,9 +87,17 @@ class TSRDownload:
     @classmethod
     def __getTSRDLTicketCookie(self) -> str:
         logger.info(f"Getting 'tsrdlticket' cookie for: {self.url.url}")
+        url = f"{self.url.downloadUrl}/ticket/{self.TSRDLTicket}"
+        response = self.session.get(url)
+        self.ticketInitializedTime = time.time() * 1000
+        set_cookie = response.headers.get("Set-Cookie")
+        return set_cookie.split(";")[0].split("=")[1] if set_cookie else ""
+    
+    @classmethod
+    def __getTSRDLTicket(self) -> str:
+        logger.info(f"Getting 'tsrdlticket' for: {self.url.url}")
         response = self.session.get(
             f"https://www.thesimsresource.com/ajax.php?c=downloads&a=initDownload&itemid={self.url.itemId}&format=zip"
         )
-        self.session.get(self.url.downloadUrl)
         self.ticketInitializedTime = time.time() * 1000
-        return response.cookies.get("tsrdlticket")
+        return response.json()['ticket']

--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -12,12 +12,21 @@ def stripForbiddenCharacters(string: str) -> str:
 class TSRDownload:
     @classmethod
     def __init__(self, url: TSRUrl, sessionId: str):
+        self.TSRDLTicket = ""
         self.url: TSRUrl = url
+        self.sessionId = sessionId
+        self.ticketInitializedTime = -1.0
         self.session: requests.Session = requests.Session()
+
+    @classmethod
+    def init(self):
+        logger.info(f"Initializing TSRDownload for: {self.url.url}")
         self.TSRDLTicket = self.__getTSRDLTicket()
-        self.session.cookies.set("tsrdlsession", sessionId or  self.__getTSRDLTicketCookie())
-        self.ticketInitializedTime: float = -1.0
-        
+        self.session.cookies.set(
+            "tsrdlsession",
+            self.sessionId or self.__getTSRDLTicketCookie()
+        )
+        self.ticketInitializedTime = time.time() * 1000
 
     @classmethod
     def download(self, downloadPath: str) -> str:

--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -98,7 +98,6 @@ class TSRDownload:
         logger.info(f"Getting 'tsrdlticket' cookie for: {self.url.url}")
         url = f"{self.url.downloadUrl}/ticket/{self.TSRDLTicket}"
         response = self.session.get(url)
-        self.ticketInitializedTime = time.time() * 1000
         set_cookie = response.headers.get("Set-Cookie")
         return set_cookie.split(";")[0].split("=")[1] if set_cookie else ""
     
@@ -108,5 +107,4 @@ class TSRDownload:
         response = self.session.get(
             f"https://www.thesimsresource.com/ajax.php?c=downloads&a=initDownload&itemid={self.url.itemId}&format=zip"
         )
-        self.ticketInitializedTime = time.time() * 1000
         return response.json()['ticket']

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ import clipboard, time, os
 def processTarget(url: TSRUrl, tsrdlsession: str, downloadPath: str):
     try:
         downloader = TSRDownload(url, tsrdlsession)
+        downloader.init()
         downloader.download(downloadPath)
         logger.info(f"Completed download for: {url.url}")
     except Exception as e:


### PR DESCRIPTION
resolves assets downloads issue for https://www.thesimsresource.com/ due to updated workflow on TSRDLTicket and unable to get valid session token for downloads. with this patch, the issue has been fixed and am able to for download assets. Thanks !!


Fixes both reported issues  https://github.com/Xientraa/The-Sims-Resource-Downloader/issues/48 & https://github.com/Xientraa/The-Sims-Resource-Downloader/issues/49