### PR TITLE
fix: resolve ticker for asset_id

### DIFF
--- a/src/TSRDownload.py
+++ b/src/TSRDownload.py
@@ -107,4 +107,5 @@ class TSRDownload:
         response = self.session.get(
             f"https://www.thesimsresource.com/ajax.php?c=downloads&a=initDownload&itemid={self.url.itemId}&format=zip"
         )
-        return response.json()['ticket']
+        ticket = response.json()['url'].split('/')[-1]
+        return ticket


### PR DESCRIPTION
resolves ticker-update issue with the site. they seem to have updated the API again, henceforth it broke and here is the fix for it.

resolves https://github.com/Xientraa/The-Sims-Resource-Downloader/issues/51